### PR TITLE
feat: #5 로그인/회원가입/로그아웃 구현 및 인증 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// lombok
@@ -38,6 +40,11 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 }
 

--- a/src/main/java/com/example/BE/auth/controller/AuthApiController.java
+++ b/src/main/java/com/example/BE/auth/controller/AuthApiController.java
@@ -1,0 +1,49 @@
+package com.example.BE.auth.controller;
+
+import com.example.BE.auth.domain.LoginRequest;
+import com.example.BE.auth.domain.SignupRequest;
+import com.example.BE.user.domain.dto.MessageResponse;
+import com.example.BE.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthApiController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(
+        @Valid @RequestBody SignupRequest signupRequest
+    ){
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(userService.signUpUser(signupRequest));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(
+        @Valid @RequestBody LoginRequest loginRequest
+    ){
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.login(loginRequest));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(
+        @AuthenticationPrincipal String email
+    ){
+        userService.logout(email);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(MessageResponse.from("로그아웃되었습니다."));
+    }
+
+}

--- a/src/main/java/com/example/BE/auth/domain/LoginRequest.java
+++ b/src/main/java/com/example/BE/auth/domain/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.example.BE.auth.domain;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest (
+    @Email(message = "이메일 형식으로 입력해 주세요.")
+    @Size(min=1, max=16, message="이메일은 최대 32자입니다.")
+    String email,
+
+    @Size(min=1, max=16, message="비밀번호는 최대 16자리입니다.")
+    String password
+){}

--- a/src/main/java/com/example/BE/auth/domain/SignupRequest.java
+++ b/src/main/java/com/example/BE/auth/domain/SignupRequest.java
@@ -1,0 +1,21 @@
+package com.example.BE.auth.domain;
+
+import com.example.BE.user.domain.UserEntity.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest (
+    @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+    @Size(min = 1, max=16, message = "닉네임은 1자~16자여야 합니다.")
+    String nickname,
+
+    @Email(message = "이메일 형식으로 입력해 주세요.")
+    @Size(min=1, max=16, message="이메일은 최대 32자입니다.")
+    String email,
+
+    @Size(min=1, max=16, message="비밀번호는 최대 16자리입니다.")
+    String password,
+
+    UserRole role
+){}

--- a/src/main/java/com/example/BE/global/config/JwtFilter.java
+++ b/src/main/java/com/example/BE/global/config/JwtFilter.java
@@ -35,8 +35,15 @@ public class JwtFilter extends OncePerRequestFilter {
         // Bearer + token string 추출
         final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        // authorization이 비어있거나 Bearer로 시작하지 않으면 다음 필터로 일단 넘김
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+        // authorization이 비어있으면 일단 security context로 넘김 -> login/signup 같은 허용 경로는
+        // 여기 조건문에 걸려서 일단 다음 filter로 넘어감.
+        if (authorization == null ) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 토큰이 Bearer로 시작하지 않으면 바로 errorResponse 전달
+        if(!authorization.startsWith("Bearer ")){
             log.warn("Invalid Token: {}", authorization);
             setErrorResponse(response, TokenErrorCode.INVALID_TOKEN);
             return;

--- a/src/main/java/com/example/BE/global/config/JwtFilter.java
+++ b/src/main/java/com/example/BE/global/config/JwtFilter.java
@@ -1,0 +1,85 @@
+package com.example.BE.global.config;
+
+import com.example.BE.global.exception.errorCode.TokenErrorCode;
+import com.example.BE.global.jwt.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        // Bearer + token string 추출
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        // authorization이 비어있거나 Bearer로 시작하지 않으면 다음 필터로 일단 넘김
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.warn("Invalid Token: {}", authorization);
+            setErrorResponse(response, TokenErrorCode.INVALID_TOKEN);
+            return;
+        }
+
+        try {
+            // Bearer 부분을 떼고 token만 추출
+            String token = authorization.split(" ")[1];
+
+            // 토큰 유효성 검사: 만료 여부, 형식 다 한 번에 체크함.
+            if(!jwtUtil.validateToken(token)){
+                throw new JwtException("Token validation failed");
+            }
+
+            // SecurityContext에 등록
+            String email = jwtUtil.getEmail(token);
+            String userRole = jwtUtil.getRole(token);
+
+            UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(email, null, List.of(
+                    new SimpleGrantedAuthority(userRole)
+                ));
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+            // next filter
+            filterChain.doFilter(request, response);
+
+        } catch(JwtException e){
+            log.warn("Invalid Token: {}", e.getMessage());
+            setErrorResponse(response, TokenErrorCode.INVALID_TOKEN);
+            return;
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, TokenErrorCode errorCode)
+        throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(errorCode.httpStatus().value());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("errorCode", errorCode.code());
+        body.put("message", errorCode.message());
+
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/BE/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/BE/global/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.example.BE.global.config;
+
+import com.example.BE.global.jwt.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(new JwtFilter(jwtUtil, new ObjectMapper()), UsernamePasswordAuthenticationFilter.class)
+            .build();
+    }
+}

--- a/src/main/java/com/example/BE/global/exception/errorCode/TokenErrorCode.java
+++ b/src/main/java/com/example/BE/global/exception/errorCode/TokenErrorCode.java
@@ -1,0 +1,30 @@
+package com.example.BE.global.exception.errorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum TokenErrorCode implements ErrorCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "T001", "토큰 형식이 올바르지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "T002", "권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/BE/global/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/example/BE/global/exception/errorCode/UserErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저 아이디입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다."),
     INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다."),
     REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "U003", "로그인이 필요합니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT,  "U004", "이미 존재하는 이메일입니다."),

--- a/src/main/java/com/example/BE/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/BE/global/jwt/JwtUtil.java
@@ -1,0 +1,71 @@
+package com.example.BE.global.jwt;
+
+import com.example.BE.user.domain.UserEntity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class JwtUtil {
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // claim 추출
+    private Claims getClaims(String token){
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    public Long getId(String token){
+        return getClaims(token).get("id", Long.class);
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token){
+        try{
+            getClaims(token);
+            return true;
+        }catch(JwtException e){
+            log.warn("Invalid Token(validateToken method): {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // 토큰 생성
+    public String generateToken(Long userId, String email, UserRole role) {
+        long expireTimeMs = 1000 * 60 * 60; // 유효기간 1시간
+        Date now = new Date();
+
+        return Jwts.builder()
+            .claim("id", userId)
+            .claim("email", email)
+            .claim("role", role.name())
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + expireTimeMs))
+            .signWith(secretKey)
+            .compact();
+    }
+
+}

--- a/src/main/java/com/example/BE/global/jwt/TokenResponse.java
+++ b/src/main/java/com/example/BE/global/jwt/TokenResponse.java
@@ -1,0 +1,9 @@
+package com.example.BE.global.jwt;
+
+public record TokenResponse(
+    String accessToken
+) {
+    public static TokenResponse from(String accessToken){
+        return new TokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/example/BE/user/domain/UserEntity.java
+++ b/src/main/java/com/example/BE/user/domain/UserEntity.java
@@ -1,7 +1,9 @@
 package com.example.BE.user.domain;
 
+import com.example.BE.auth.domain.SignupRequest;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Table(name = "user")
@@ -35,9 +37,9 @@ public class UserEntity {
     private Long points;
 
     @Builder
-    public UserEntity(String email, String password, String nickname, UserRole role, Long points) {
+    public UserEntity(String email, String password, String nickname, UserRole role, Long points, PasswordEncoder passwordEncoder) {
         this.email = email;
-        this.password = password;
+        this.password = passwordEncoder.encode(password);
         this.nickname = nickname;
         this.role = role;
         this.points = points;
@@ -48,5 +50,16 @@ public class UserEntity {
         if (nickname != null && !nickname.isBlank()) {
             this.nickname = nickname;
         }
+    }
+
+    public static UserEntity from(SignupRequest signupRequest, PasswordEncoder passwordEncoder){
+        return new UserEntity(
+            signupRequest.email(),
+            signupRequest.password(),
+            signupRequest.nickname(),
+            signupRequest.role(),
+            0L,
+            passwordEncoder
+        );
     }
 }

--- a/src/main/java/com/example/BE/user/repository/UserRepository.java
+++ b/src/main/java/com/example/BE/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/BE/user/service/UserService.java
+++ b/src/main/java/com/example/BE/user/service/UserService.java
@@ -1,23 +1,33 @@
 package com.example.BE.user.service;
 
+import com.example.BE.auth.domain.LoginRequest;
+import com.example.BE.auth.domain.SignupRequest;
 import com.example.BE.global.exception.CustomException;
 import com.example.BE.global.exception.errorCode.UserErrorCode;
+import com.example.BE.global.jwt.JwtUtil;
+import com.example.BE.global.jwt.TokenResponse;
 import com.example.BE.user.domain.UserEntity;
 import com.example.BE.user.domain.dto.UserResponse;
 import com.example.BE.user.domain.dto.UserUpdateRequest;
 import com.example.BE.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     // 단일 유저 조회
+    @Transactional
     public UserResponse findById(Long userId) {
         UserEntity user = findByIdOrThrow(userId);
         return UserResponse.from(user);
@@ -37,6 +47,39 @@ public class UserService {
     public void deleteUser(Long userId) {
         findByIdOrThrow(userId);
         userRepository.deleteById(userId);
+    }
+
+    // 회원가입
+    @Transactional
+    public UserResponse signUpUser(SignupRequest signupRequest){
+        if(userRepository.existsByEmail(signupRequest.email())){
+            throw CustomException.from(UserErrorCode.DUPLICATE_EMAIL);
+        }
+        UserEntity user = UserEntity.from(signupRequest, passwordEncoder);
+        return UserResponse.from(userRepository.save(user));
+    }
+
+    // 로그인
+    @Transactional
+    public TokenResponse login(LoginRequest loginRequest){
+        UserEntity user = userRepository.findByEmail(loginRequest.email())
+            .orElseThrow(()->CustomException.from(UserErrorCode.NOT_FOUND));
+
+        // 비밀번호 일치하지 않음
+        if(!passwordEncoder.matches(loginRequest.password(), user.getPassword())){
+            throw CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD);
+        }
+
+        return TokenResponse.from(jwtUtil.generateToken(
+            user.getId(),
+            user.getEmail(),
+            user.getRole()
+        ));
+    }
+
+    // 로그아웃
+    public void logout(String email){
+        log.info("logout reqeust by : {}", email);
     }
 
     private UserEntity findByIdOrThrow(Long userId){

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,4 +22,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  jwt:
+    secret: ${SECRET_KEY}
+
+# 요청 응답에 모두 한글 인코딩 강제 적용
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
 


### PR DESCRIPTION
## ✨ 요약
- 로그인/회원가입/로그아웃 API를 구현하고, 인증 처리 로직을 추가했어요.

<br><br>

## 🔗 작업 내용
- 로그인/회원가입/로그아웃 API 구현
- JwtFilter, Spring security를 통한 인증 구현
- TokenReseponse, TokenErrorCode 구현

<br><br>

## 🔗 참고 사항
- email/password로 로그인 시에 accessToken만 발급해 줍니다.(유효기간: 1시간)
- 토큰이 `Bearer `로 시작하지 않거나, 유효하지 않으면 filter 단에서 HttpServletResponse를 작성해 바로 전달합니다.
- 토큰을 넣지 않고 요청을 보내면 일단 security context로 넘어갑니다. 허용 경로(login/signup)이면 그대로 요청을 수행하고, 허용 경로가 아니면 403 FORBIDDEN을 반환합니다.

<br><br>

## 🔗 관련 이슈

- #5 

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입, 로그인, 로그아웃 API 추가 및 JWT 기반 인증 적용
  - 사용자 프로필 조회/수정/삭제 API 제공
  - 유효성 검사 메시지 및 표준화된 에러 응답 도입

- 변경
  - 애플리케이션 데이터베이스를 MySQL로 전환
  - 보안, 검증, 마이그레이션, JWT 관련 의존성 추가

- 인프라
  - 로컬 개발용 애플리케이션·데이터베이스 도커 컴포즈 환경 추가
  - 애플리케이션 설정에 포트, 문자 인코딩, JWT 시크릿 구성 반영

- 잡무
  - 개발 보조 도구 설정 추가
  - 환경파일 무시 규칙 갱신 (.gitignore)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->