### PR TITLE
feat:#5 로그인/회원가입/로그아웃 구현 및 인증 로직 구현 피드백 반영(실수로 PR 닫아서 다시 요청함)

### DIFF
--- a/src/main/java/com/example/BE/auth/domain/LoginRequest.java
+++ b/src/main/java/com/example/BE/auth/domain/LoginRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record LoginRequest (
     @Email(message = "이메일 형식으로 입력해 주세요.")
-    @Size(min=1, max=16, message="이메일은 최대 32자입니다.")
+    @Size(min=1, max=32, message="이메일은 최대 32자입니다.")
     String email,
 
     @Size(min=1, max=16, message="비밀번호는 최대 16자리입니다.")

--- a/src/main/java/com/example/BE/auth/domain/SignupRequest.java
+++ b/src/main/java/com/example/BE/auth/domain/SignupRequest.java
@@ -11,7 +11,7 @@ public record SignupRequest (
     String nickname,
 
     @Email(message = "이메일 형식으로 입력해 주세요.")
-    @Size(min=1, max=16, message="이메일은 최대 32자입니다.")
+    @Size(min=1, max=32, message="이메일은 최대 32자입니다.")
     String email,
 
     @Size(min=1, max=16, message="비밀번호는 최대 16자리입니다.")

--- a/src/main/java/com/example/BE/global/config/JwtFilter.java
+++ b/src/main/java/com/example/BE/global/config/JwtFilter.java
@@ -18,10 +18,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 @Slf4j
+@Component
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/example/BE/global/config/JwtFilter.java
+++ b/src/main/java/com/example/BE/global/config/JwtFilter.java
@@ -51,7 +51,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         try {
             // Bearer 부분을 떼고 token만 추출
-            String token = authorization.split(" ")[1];
+            String token = authorization.substring("Bearer ".length());
 
             // 토큰 유효성 검사: 만료 여부, 형식 다 한 번에 체크함.
             if(!jwtUtil.validateToken(token)){

--- a/src/main/java/com/example/BE/global/config/JwtFilter.java
+++ b/src/main/java/com/example/BE/global/config/JwtFilter.java
@@ -3,7 +3,6 @@ package com.example.BE.global.config;
 import com.example.BE.global.exception.errorCode.TokenErrorCode;
 import com.example.BE.global.jwt.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,45 +36,40 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // authorization이 비어있으면 일단 security context로 넘김 -> login/signup 같은 허용 경로는
         // 여기 조건문에 걸려서 일단 다음 filter로 넘어감.
-        if (authorization == null ) {
+        if (authorization == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
         // 토큰이 Bearer로 시작하지 않으면 바로 errorResponse 전달
-        if(!authorization.startsWith("Bearer ")){
+        if (!authorization.startsWith("Bearer ")) {
             log.warn("Invalid Token: {}", authorization);
             setErrorResponse(response, TokenErrorCode.INVALID_TOKEN);
             return;
         }
 
-        try {
-            // Bearer 부분을 떼고 token만 추출
-            String token = authorization.substring("Bearer ".length());
+        // Bearer 부분을 떼고 token만 추출
+        String token = authorization.substring("Bearer ".length());
 
-            // 토큰 유효성 검사: 만료 여부, 형식 다 한 번에 체크함.
-            if(!jwtUtil.validateToken(token)){
-                throw new JwtException("Token validation failed");
-            }
-
-            // SecurityContext에 등록
-            String email = jwtUtil.getEmail(token);
-            String userRole = jwtUtil.getRole(token);
-
-            UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(email, null, List.of(
-                    new SimpleGrantedAuthority(userRole)
-                ));
-            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-
-            // next filter
-            filterChain.doFilter(request, response);
-
-        } catch(JwtException e){
-            log.warn("Invalid Token: {}", e.getMessage());
+        // 토큰 유효성 검사: 만료 여부, 형식 다 한 번에 체크함.
+        if (!jwtUtil.validateToken(token)) {
             setErrorResponse(response, TokenErrorCode.INVALID_TOKEN);
             return;
         }
+
+        // SecurityContext에 등록
+        String email = jwtUtil.getEmail(token);
+        String userRole = jwtUtil.getRole(token);
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(email, null, List.of(
+                new SimpleGrantedAuthority(userRole)
+            ));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        // next filter
+        filterChain.doFilter(request, response);
+
     }
 
     private void setErrorResponse(HttpServletResponse response, TokenErrorCode errorCode)

--- a/src/main/java/com/example/BE/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/BE/global/config/SecurityConfig.java
@@ -17,8 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-    private final JwtUtil jwtUtil;
+    private final JwtFilter jwtFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -34,7 +33,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()
                 .anyRequest().authenticated()
             )
-            .addFilterBefore(new JwtFilter(jwtUtil, new ObjectMapper()), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 }

--- a/src/main/java/com/example/BE/global/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/example/BE/global/exception/errorCode/UserErrorCode.java
@@ -9,7 +9,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다."),
     REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "U003", "로그인이 필요합니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT,  "U004", "이미 존재하는 이메일입니다."),
-    NOT_ADMIN(HttpStatus.FORBIDDEN, "U005", "어드민이 아닙니다.");
+    NOT_ADMIN(HttpStatus.FORBIDDEN, "U005", "어드민이 아닙니다."),
+    NOT_ALLOWED_ADMIN(HttpStatus.FORBIDDEN, "U006", "어드민 계정 생성은 관리자에게 문의해주세요");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/BE/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/BE/global/jwt/JwtUtil.java
@@ -16,9 +16,11 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class JwtUtil {
     private final SecretKey secretKey;
+    private final Long expiryTime;
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret, @Value("${spring.jwt.expiryTime}") Long expiryTime,) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiryTime = expiryTime;
     }
 
     // claim 추출
@@ -55,7 +57,7 @@ public class JwtUtil {
 
     // 토큰 생성
     public String generateToken(Long userId, String email, UserRole role) {
-        long expireTimeMs = 1000 * 60 * 60; // 유효기간 1시간
+        long expireTimeMs = expiryTime; // 유효기간 1시간
         Date now = new Date();
 
         return Jwts.builder()

--- a/src/main/java/com/example/BE/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/BE/global/jwt/JwtUtil.java
@@ -15,16 +15,18 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class JwtUtil {
+
     private final SecretKey secretKey;
     private final Long expiryTime;
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secret, @Value("${spring.jwt.expiryTime}") Long expiryTime,) {
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret,
+        @Value("${spring.jwt.expiryTime}") Long expiryTime) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.expiryTime = expiryTime;
     }
 
     // claim 추출
-    private Claims getClaims(String token){
+    private Claims getClaims(String token) {
         return Jwts.parser()
             .verifyWith(secretKey)
             .build()
@@ -32,7 +34,7 @@ public class JwtUtil {
             .getPayload();
     }
 
-    public Long getId(String token){
+    public Long getId(String token) {
         return getClaims(token).get("id", Long.class);
     }
 
@@ -45,11 +47,11 @@ public class JwtUtil {
     }
 
     // 토큰 유효성 검사
-    public boolean validateToken(String token){
-        try{
+    public boolean validateToken(String token) {
+        try {
             getClaims(token);
             return true;
-        }catch(JwtException e){
+        } catch (JwtException e) {
             log.warn("Invalid Token(validateToken method): {}", e.getMessage());
             return false;
         }

--- a/src/main/java/com/example/BE/user/domain/UserEntity.java
+++ b/src/main/java/com/example/BE/user/domain/UserEntity.java
@@ -1,8 +1,20 @@
 package com.example.BE.user.domain;
 
 import com.example.BE.auth.domain.SignupRequest;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
@@ -12,37 +24,38 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
 
-    public enum UserRole {
-        ROLE_CUSTOMER, ROLE_OWNER, ROLE_ADMIN
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Column(name = "email", length = 32)
     private String email;
-
     @Column(name = "password")
     private String password;
-
     @Column(name = "nickname", length = 16)
     private String nickname;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 20)
     private UserRole role;
-
     @Column(name = "points")
     private Long points;
 
     @Builder
-    public UserEntity(String email, String password, String nickname, UserRole role, Long points, PasswordEncoder passwordEncoder) {
+    public UserEntity(String email, String password, String nickname, UserRole role, Long points) {
         this.email = email;
-        this.password = passwordEncoder.encode(password);
+        this.password = password;
         this.nickname = nickname;
         this.role = role;
         this.points = points;
+    }
+
+    public static UserEntity from(SignupRequest signupRequest, PasswordEncoder passwordEncoder) {
+        return new UserEntity(
+            signupRequest.email(),
+            passwordEncoder.encode(signupRequest.password()),
+            signupRequest.nickname(),
+            signupRequest.role(),
+            0L
+        );
     }
 
     // 현재는 nickname만 수정이 가능합니다.
@@ -52,14 +65,7 @@ public class UserEntity {
         }
     }
 
-    public static UserEntity from(SignupRequest signupRequest, PasswordEncoder passwordEncoder){
-        return new UserEntity(
-            signupRequest.email(),
-            signupRequest.password(),
-            signupRequest.nickname(),
-            signupRequest.role(),
-            0L,
-            passwordEncoder
-        );
+    public enum UserRole {
+        ROLE_CUSTOMER, ROLE_OWNER, ROLE_ADMIN
     }
 }

--- a/src/main/java/com/example/BE/user/domain/UserEntity.java
+++ b/src/main/java/com/example/BE/user/domain/UserEntity.java
@@ -1,6 +1,7 @@
 package com.example.BE.user.domain;
 
 import com.example.BE.auth.domain.SignupRequest;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -26,16 +27,22 @@ public class UserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "email", length = 32)
+
+    @Column(name = "email", length = 32, nullable = false, unique = true)
     private String email;
-    @Column(name = "password")
+
+    @Column(name = "password", nullable = false)
+    @JsonIgnore
     private String password;
-    @Column(name = "nickname", length = 16)
+
+    @Column(name = "nickname", length = 16, nullable = false)
     private String nickname;
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", length = 20)
+    @Column(name = "role", length = 20, nullable = false)
     private UserRole role;
-    @Column(name = "points")
+
+    @Column(name = "points", nullable = false)
     private Long points;
 
     private UserEntity(String email, String password, String nickname, UserRole role, Long points) {

--- a/src/main/java/com/example/BE/user/domain/UserEntity.java
+++ b/src/main/java/com/example/BE/user/domain/UserEntity.java
@@ -12,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -39,8 +38,7 @@ public class UserEntity {
     @Column(name = "points")
     private Long points;
 
-    @Builder
-    public UserEntity(String email, String password, String nickname, UserRole role, Long points) {
+    private UserEntity(String email, String password, String nickname, UserRole role, Long points) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/example/BE/user/service/UserService.java
+++ b/src/main/java/com/example/BE/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.example.BE.global.exception.errorCode.UserErrorCode;
 import com.example.BE.global.jwt.JwtUtil;
 import com.example.BE.global.jwt.TokenResponse;
 import com.example.BE.user.domain.UserEntity;
+import com.example.BE.user.domain.UserEntity.UserRole;
 import com.example.BE.user.domain.dto.UserResponse;
 import com.example.BE.user.domain.dto.UserUpdateRequest;
 import com.example.BE.user.repository.UserRepository;
@@ -55,6 +56,12 @@ public class UserService {
         if(userRepository.existsByEmail(signupRequest.email())){
             throw CustomException.from(UserErrorCode.DUPLICATE_EMAIL);
         }
+
+        // userRole을 어드민으로 요청하면 바로 예외 발생
+        if(signupRequest.role()== UserRole.ROLE_ADMIN){
+            throw CustomException.from(UserErrorCode.NOT_ALLOWED_ADMIN);
+        }
+
         UserEntity user = UserEntity.from(signupRequest, passwordEncoder);
         return UserResponse.from(userRepository.save(user));
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,8 @@ spring:
         format_sql: true
   jwt:
     secret: ${SECRET_KEY}
+    # 토큰 유효기간: 1시간
+    expiryTime: 3600000 
 
 # 요청 응답에 모두 한글 인코딩 강제 적용
 server:


### PR DESCRIPTION
## ✨ 요약
- #12 PR의 피드백 사항들을 반영했습니다.

<br><br>

## 🔗 작업 내용
- #12 PR 피드백 사항들 반영

<br><br>

## 🔗 참고 사항
- 실수로 #12 PR 닫고 push를 해버려서 그냥 다시 PR 요청했어요.

<br><br>

## 🔗 관련 이슈

- Close #5

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 로그인/회원가입 이메일 최대 길이를 32자로 확장.
  - 관리자 권한(ADMIN)으로의 회원가입을 차단하고 안내 메시지 제공.
  - JWT 토큰 유효기간을 설정값으로 관리(기본 1시간).

- 리팩터
  - 인증 필터를 빈으로 주입하도록 변경 및 예외 처리/검증 흐름 정비.
  - 사용자 엔티티 생성 방식을 팩토리 메서드로 정리하고 접근자와 역할(enum) 추가.

- 작업
  - 애플리케이션 설정에 JWT 만료시간 항목 추가.
  - 사용자 관련 오류 코드 항목 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->