### PR TITLE
feat: #15 메뉴 도메인 CRUD API 구현

### DIFF
--- a/src/main/java/com/example/BE/auth/domain/SignupRequest.java
+++ b/src/main/java/com/example/BE/auth/domain/SignupRequest.java
@@ -3,6 +3,7 @@ package com.example.BE.auth.domain;
 import com.example.BE.user.domain.UserEntity.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest (
@@ -17,5 +18,6 @@ public record SignupRequest (
     @Size(min=1, max=16, message="비밀번호는 최대 16자리입니다.")
     String password,
 
+    @NotNull(message = "유저 타입은 필수 정보입니다.")
     UserRole role
 ){}

--- a/src/main/java/com/example/BE/global/exception/errorCode/MenuErrorCode.java
+++ b/src/main/java/com/example/BE/global/exception/errorCode/MenuErrorCode.java
@@ -1,0 +1,30 @@
+package com.example.BE.global.exception.errorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MenuErrorCode implements ErrorCode {
+
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 메뉴입니다."),
+    FORBIDDEN_STORE_ACCESS(HttpStatus.FORBIDDEN, "M002", "해당 메뉴에 대한 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/BE/global/exception/errorCode/MenuErrorCode.java
+++ b/src/main/java/com/example/BE/global/exception/errorCode/MenuErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum MenuErrorCode implements ErrorCode {
 
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 메뉴입니다."),
-    FORBIDDEN_STORE_ACCESS(HttpStatus.FORBIDDEN, "M002", "해당 메뉴에 대한 접근 권한이 없습니다.");
+    FORBIDDEN_MENU_ACCESS(HttpStatus.FORBIDDEN, "M002", "해당 메뉴에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/BE/menu/controller/MenuApiController.java
+++ b/src/main/java/com/example/BE/menu/controller/MenuApiController.java
@@ -4,6 +4,7 @@ import com.example.BE.menu.domain.dto.MenuCreateRequest;
 import com.example.BE.menu.domain.dto.MenuResponse;
 import com.example.BE.menu.domain.dto.MenuUpdateRequest;
 import com.example.BE.menu.service.MenuService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class MenuApiController {
     @PostMapping
     public ResponseEntity<MenuResponse> createMenu(
         @AuthenticationPrincipal Long userId,
-        @RequestBody MenuCreateRequest request
+        @Valid @RequestBody MenuCreateRequest request
     ) {
         MenuResponse response = menuService.createMenu(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/example/BE/menu/controller/MenuApiController.java
+++ b/src/main/java/com/example/BE/menu/controller/MenuApiController.java
@@ -1,0 +1,70 @@
+package com.example.BE.menu.controller;
+
+import com.example.BE.menu.domain.dto.MenuCreateRequest;
+import com.example.BE.menu.domain.dto.MenuResponse;
+import com.example.BE.menu.domain.dto.MenuUpdateRequest;
+import com.example.BE.menu.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/menu")
+@RequiredArgsConstructor
+public class MenuApiController {
+
+    private final MenuService menuService;
+
+    // 메뉴 생성
+    @PostMapping
+    public ResponseEntity<MenuResponse> createMenu(
+        @AuthenticationPrincipal Long userId,
+        @RequestBody MenuCreateRequest request
+    ) {
+        MenuResponse response = menuService.createMenu(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 메뉴 단일 조회: 거의 사용 안 할 듯
+    @GetMapping("/{menuId}")
+    public ResponseEntity<MenuResponse> getMenu(
+        @PathVariable Long menuId
+    ) {
+        MenuResponse response = menuService.getMenuById(menuId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 특정 가게 메뉴 리스트 조회
+    @GetMapping("/list/{storeId}")
+    public ResponseEntity<List<MenuResponse>> getMenuList(
+        @PathVariable Long storeId
+    ) {
+        List<MenuResponse> response = menuService.getMenusByStoreId(storeId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 메뉴 정보 수정
+    @PatchMapping("/{menuId}")
+    public ResponseEntity<MenuResponse> updateMenu(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long menuId,
+        @RequestBody MenuUpdateRequest request
+    ) {
+        MenuResponse response = menuService.updateMenu(userId, menuId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 메뉴 삭제
+    @DeleteMapping("/{menuId}")
+    public ResponseEntity<Void> deleteMenu(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long menuId
+    ) {
+        menuService.deleteMenu(userId, menuId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/example/BE/menu/domain/MenuEntity.java
+++ b/src/main/java/com/example/BE/menu/domain/MenuEntity.java
@@ -55,7 +55,7 @@ public class MenuEntity {
     // 메뉴 정보 수정
     public void update(MenuUpdateRequest request) {
         if (request.name() != null) this.name = request.name();
-        if (request.price()!=null && request.price() > 0) this.price = request.price();
+        if (request.price()!=null && request.price() >= 0) this.price = request.price();
         if (request.description() != null) this.description = request.description();
         if (request.imageUrl() != null) this.imageUrl = request.imageUrl();
     }

--- a/src/main/java/com/example/BE/menu/domain/MenuEntity.java
+++ b/src/main/java/com/example/BE/menu/domain/MenuEntity.java
@@ -1,5 +1,7 @@
-package com.example.BE.menu.domain; // 패키지 경로는 프로젝트에 맞게 조정하세요.
+package com.example.BE.menu.domain;
 
+import com.example.BE.menu.domain.dto.MenuCreateRequest;
+import com.example.BE.menu.domain.dto.MenuUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -40,11 +42,21 @@ public class MenuEntity {
         this.imageUrl = imageUrl;
     }
 
+    public static MenuEntity from(MenuCreateRequest request){
+        return new MenuEntity(
+            request.storeId(),
+            request.name(),
+            request.price(),
+            request.description(),
+            request.imageUrl()
+        );
+    }
+
     // 메뉴 정보 수정
-    public void update(String name, int price, String description, String imageUrl) {
-        if (name != null) this.name = name;
-        if (price > 0) this.price = price; // 가격은 0보다 클 때만 수정되도록 설계
-        if (description != null) this.description = description;
-        if (imageUrl != null) this.imageUrl = imageUrl;
+    public void update(MenuUpdateRequest request) {
+        if (request.name() != null) this.name = request.name();
+        if (request.price()!=null && request.price() > 0) this.price = request.price();
+        if (request.description() != null) this.description = request.description();
+        if (request.imageUrl() != null) this.imageUrl = request.imageUrl();
     }
 }

--- a/src/main/java/com/example/BE/menu/domain/MenuEntity.java
+++ b/src/main/java/com/example/BE/menu/domain/MenuEntity.java
@@ -1,0 +1,50 @@
+package com.example.BE.menu.domain; // 패키지 경로는 프로젝트에 맞게 조정하세요.
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "menu")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "name", length = 32, nullable = false)
+    private String name;
+
+    @Column(name = "price")
+    private int price;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
+
+    @Builder
+    public MenuEntity(Long storeId, String name, int price, String description, String imageUrl) {
+        this.storeId = storeId;
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+
+    // 메뉴 정보 수정
+    public void update(String name, int price, String description, String imageUrl) {
+        if (name != null) this.name = name;
+        if (price > 0) this.price = price; // 가격은 0보다 클 때만 수정되도록 설계
+        if (description != null) this.description = description;
+        if (imageUrl != null) this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
@@ -2,13 +2,18 @@ package com.example.BE.menu.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record MenuCreateRequest(
     @NotNull(message = "가게ID는 필수값입니다.")
+    @Positive(message = "가게ID는 1이상입니다.")
     Long storeId,
 
-    @NotBlank(message = "가게명은 필수값입니다.")
+    @NotBlank(message = "메뉴명은 필수값입니다.")
     String name,
+
+    @PositiveOrZero(message = "가격은 0원 이상이어야 합니다.")
     int price,
     String description,
     String imageUrl

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
@@ -1,7 +1,13 @@
 package com.example.BE.menu.domain.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record MenuCreateRequest(
+    @NotNull(message = "가게ID는 필수값입니다.")
     Long storeId,
+
+    @NotBlank(message = "가게명은 필수값입니다.")
     String name,
     int price,
     String description,

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
@@ -1,0 +1,9 @@
+package com.example.BE.menu.domain.dto;
+
+public record MenuCreateRequest(
+    Long storeId,
+    String name,
+    int price,
+    String description,
+    String imageUrl
+) {}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 public record MenuCreateRequest(
     @NotNull(message = "가게ID는 필수값입니다.")
@@ -11,10 +12,13 @@ public record MenuCreateRequest(
     Long storeId,
 
     @NotBlank(message = "메뉴명은 필수값입니다.")
+    @Size(max=32, message="메뉴명은 최대 32자입니다.")
     String name,
 
     @PositiveOrZero(message = "가격은 0원 이상이어야 합니다.")
     int price,
+
+    @Size(max=255, message="메뉴 설명은 최대 255자입니다.")
     String description,
     String imageUrl
 ) {}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuResponse.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuResponse.java
@@ -1,0 +1,23 @@
+package com.example.BE.menu.domain.dto;
+
+import com.example.BE.menu.domain.MenuEntity;
+
+public record MenuResponse(
+    Long id,
+    Long storeId,
+    String name,
+    int price,
+    String description,
+    String imageUrl
+) {
+    public static MenuResponse from(MenuEntity menu) {
+        return new MenuResponse(
+            menu.getId(),
+            menu.getStoreId(),
+            menu.getName(),
+            menu.getPrice(),
+            menu.getDescription(),
+            menu.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
@@ -2,7 +2,8 @@ package com.example.BE.menu.domain.dto;
 
 public record MenuUpdateRequest(
     String name,
-    Integer price, // int 대신 Integer를 사용하여 null 체크 -> 애매함
+    // 수정 요청 시에 null을 받을 수 있도록 Wrapper 사용.(의도함)
+    Integer price,
     String description,
     String imageUrl
 ) {}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.example.BE.menu.domain.dto;
+
+public record MenuUpdateRequest(
+    String name,
+    Integer price, // int 대신 Integer를 사용하여 null 체크 -> 애매함
+    String description,
+    String imageUrl
+) {}

--- a/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
+++ b/src/main/java/com/example/BE/menu/domain/dto/MenuUpdateRequest.java
@@ -1,8 +1,11 @@
 package com.example.BE.menu.domain.dto;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record MenuUpdateRequest(
     String name,
     // 수정 요청 시에 null을 받을 수 있도록 Wrapper 사용.(의도함)
+    @PositiveOrZero(message = "가격은 0원 이상이어야 합니다.")
     Integer price,
     String description,
     String imageUrl

--- a/src/main/java/com/example/BE/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/BE/menu/repository/MenuRepository.java
@@ -1,0 +1,11 @@
+package com.example.BE.menu.repository;
+
+import com.example.BE.menu.domain.MenuEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenuRepository extends JpaRepository<MenuEntity, Long> {
+
+    List<MenuEntity> findByStoreId(Long storeId);
+}

--- a/src/main/java/com/example/BE/menu/service/MenuService.java
+++ b/src/main/java/com/example/BE/menu/service/MenuService.java
@@ -1,0 +1,86 @@
+package com.example.BE.menu.service;
+
+import com.example.BE.global.exception.CustomException;
+import com.example.BE.global.exception.errorCode.MenuErrorCode;
+import com.example.BE.global.exception.errorCode.StoreErrorCode;
+import com.example.BE.menu.domain.MenuEntity;
+import com.example.BE.menu.domain.dto.MenuCreateRequest;
+import com.example.BE.menu.domain.dto.MenuResponse;
+import com.example.BE.menu.domain.dto.MenuUpdateRequest;
+import com.example.BE.menu.repository.MenuRepository;
+import com.example.BE.store.domain.StoreEntity;
+import com.example.BE.store.repository.StoreRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public MenuResponse createMenu(Long userId, MenuCreateRequest request) {
+        StoreEntity store = findStoreByIdOrThrow(request.storeId());
+
+        // 가게 주인만 메뉴 생성/수정/삭제할 수 있도록 함.
+        validateStoreOwner(userId, store);
+
+        MenuEntity newMenu = MenuEntity.from(request);
+
+        return MenuResponse.from(menuRepository.save(newMenu));
+    }
+
+    public MenuResponse getMenuById(Long menuId) {
+        MenuEntity menu = findByIdOrThrow(menuId);
+        return MenuResponse.from(menu);
+    }
+
+    public List<MenuResponse> getMenusByStoreId(Long storeId) {
+        List<MenuEntity> menus = menuRepository.findByStoreId(storeId);
+        return menus.stream()
+            .map(MenuResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public MenuResponse updateMenu(Long userId, Long menuId, MenuUpdateRequest request) {
+        MenuEntity menu = findByIdOrThrow(menuId);
+        StoreEntity store = findStoreByIdOrThrow(menu.getStoreId());
+        validateStoreOwner(userId, store);
+
+        menu.update(request);
+        return MenuResponse.from(menu);
+    }
+
+    @Transactional
+    public void deleteMenu(Long userId, Long menuId) {
+        MenuEntity menu = findByIdOrThrow(menuId);
+        StoreEntity store = findStoreByIdOrThrow(menu.getStoreId());
+        validateStoreOwner(userId, store);
+
+        menuRepository.deleteById(menuId);
+    }
+
+    private MenuEntity findByIdOrThrow(Long menuId) {
+        return menuRepository.findById(menuId)
+            .orElseThrow(() -> CustomException.from(MenuErrorCode.MENU_NOT_FOUND));
+    }
+
+    private StoreEntity findStoreByIdOrThrow(Long storeId) {
+        return storeRepository.findById(storeId)
+            .orElseThrow(() -> CustomException.from(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    // 요청한 사용자가 메뉴를 생성/수정/삭제할 수 있는 권한을 가졌는지 확인
+    private void validateStoreOwner(Long userId, StoreEntity store) {
+        if (!store.getUserId().equals(userId)) {
+            throw CustomException.from(MenuErrorCode.FORBIDDEN_MENU_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/example/BE/store/domain/StoreEntity.java
+++ b/src/main/java/com/example/BE/store/domain/StoreEntity.java
@@ -33,7 +33,7 @@ public class StoreEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "name", length = 20, nullable = false)
+    @Column(name = "name", length = 20, nullable = false, unique = true)
     private String name;
 
     @Column(name = "canonical_name", length = 20)

--- a/src/main/java/com/example/BE/store/domain/dto/StoreCreateRequest.java
+++ b/src/main/java/com/example/BE/store/domain/dto/StoreCreateRequest.java
@@ -24,7 +24,7 @@ public record StoreCreateRequest(
     Double longitude,
     String description,
 
-    @NotBlank(message = "카테고리 정보는 필수입니다.")
+    @NotNull(message = "카테고리 정보는 필수입니다.")
     StoreCategory category,
     String imageUrl,
 

--- a/src/main/java/com/example/BE/store/domain/dto/StoreCreateRequest.java
+++ b/src/main/java/com/example/BE/store/domain/dto/StoreCreateRequest.java
@@ -5,11 +5,14 @@ import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record StoreCreateRequest(
     @NotBlank(message = "가게 이름은 필수입니다.")
+    @Size(max=32, message = "가게명은 최대 32자까지 가능합니다.")
     String name,
     @NotBlank(message = "가게 주소는 필수입니다.")
+    @Size(max=255, message = "주소명은 최대 255자까지 가능합니다.")
     String address,
 
     @NotNull(message = "위도 정보는 필수입니다.")
@@ -24,5 +27,7 @@ public record StoreCreateRequest(
     @NotBlank(message = "카테고리 정보는 필수입니다.")
     StoreCategory category,
     String imageUrl,
+
+    @Size(max=255, message = "영업시간 입력은 최대 255자까지 가능합니다.")
     String openingTime
 ) {}


### PR DESCRIPTION
## ✨ 요약
- 지도 페이지와 사장님 페이지에서 보여줄 메뉴 객체에 대해 CRUD API를 구현했어요.

<br><br>

## 🔗 작업 내용
- 메뉴 CRUD API(단일 조회, 리스트 조회, 생성, 수정, 삭제) 구현
- 메뉴 생성 API에 validation 추가
- MenuErrorCode 생성 및 예외처리 로직 추가
- 사장님 본인만 본인 가게 메뉴에 대해 생성/수정/삭제할 수 있도록 인증 로직 구현

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈

- #15 

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메뉴 관리 API 추가: 생성, 조회, 가게별 목록 조회, 수정, 삭제 엔드포인트 제공
  * 도메인 모델·저장소 추가: 메뉴 엔티티 및 가게별 조회 지원
  * 요청/응답 DTO 추가: 생성·수정 유효성 검사 및 응답 포맷 정형화
  * 접근 제어 강화: 가게 소유자만 생성·수정·삭제 가능
  * 오류 코드 추가: 메뉴 미존재(M001) 및 접근권한 없음(M002) 일관된 에러 응답 제공
* **Chores**
  * 회원 가입 요청 유효성 강화: role 필수화
  * 가게 엔티티 제약 강화: 가게명 DB 유니크 제약 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->