### PR TITLE
feat: 가게 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
@@ -15,6 +15,7 @@ import com.example.BE.store.domain.StoreEntity;
 import com.example.BE.store.repository.StoreRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -116,14 +117,14 @@ public class AnnouncementService {
     // 수정/삭제하려는 개선사항의 가게 주인이 API 요청한 유저가 맞는지 확인하는 메서드
     private void validateStoreOwner(Long userId, Long storeId) {
         StoreEntity store = findStoreByIdOrThrow(storeId);
-        if (!store.getUserId().equals(userId)) {
+        if (Objects.equals(store.getUserId(), userId)) {
             throw CustomException.from(AnnouncementErrorCode.FORBIDDEN_ANNOUNCEMENT_ACCESS);
         }
     }
 
     // 참조할 feedback이 해당 가게에 속하는 feedback인지 검증하는 메서드
     private void validateFeedbackBelongsToStore(FeedbackEntity feedback, Long storeId){
-        if(!storeId.equals(feedback.getStoreId())){
+        if(Objects.equals(storeId, feedback.getStoreId())){
             throw CustomException.from(FeedbackErrorCode.FORBIDDEN_FEEDBACK_ACCESS);
         }
     }

--- a/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
@@ -115,14 +115,14 @@ public class AnnouncementService {
     // 수정/삭제하려는 개선사항의 가게 주인이 API 요청한 유저가 맞는지 확인하는 메서드
     private void validateStoreOwner(Long userId, Long storeId) {
         StoreEntity store = findStoreByIdOrThrow(storeId);
-        if (Objects.equals(store.getUserId(), userId)) {
+        if (!Objects.equals(store.getUserId(), userId)) {
             throw CustomException.from(AnnouncementErrorCode.FORBIDDEN_ANNOUNCEMENT_ACCESS);
         }
     }
 
     // 참조할 feedback이 해당 가게에 속하는 feedback인지 검증하는 메서드
     private void validateFeedbackBelongsToStore(FeedbackEntity feedback, Long storeId){
-        if(Objects.equals(storeId, feedback.getStoreId())){
+        if(!Objects.equals(storeId, feedback.getStoreId())){
             throw CustomException.from(FeedbackErrorCode.FORBIDDEN_FEEDBACK_ACCESS);
         }
     }

--- a/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/example/BE/announcement/service/AnnouncementService.java
@@ -67,10 +67,8 @@ public class AnnouncementService {
 
         // feedbackMap에서 feedbackId와 매핑되는 feedbackContent들을 하나씩 AnnouncementResponse에 담음.
         return announcements.stream()
-            .map(announcement -> {
-                return AnnouncementResponse.of(announcement,
-                    feedbackMap.get(announcement.getFeedbackId()));
-            })
+            .map(announcement -> AnnouncementResponse.of(announcement,
+                feedbackMap.get(announcement.getFeedbackId())))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/BE/menu/service/MenuService.java
+++ b/src/main/java/com/example/BE/menu/service/MenuService.java
@@ -80,7 +80,7 @@ public class MenuService {
 
     // 요청한 사용자가 메뉴를 생성/수정/삭제할 수 있는 권한을 가졌는지 확인
     private void validateStoreOwner(Long userId, StoreEntity store) {
-        if (Objects.equals(store.getUserId(), userId)) {
+        if (!Objects.equals(store.getUserId(), userId)) {
             throw CustomException.from(MenuErrorCode.FORBIDDEN_MENU_ACCESS);
         }
     }

--- a/src/main/java/com/example/BE/menu/service/MenuService.java
+++ b/src/main/java/com/example/BE/menu/service/MenuService.java
@@ -11,6 +11,7 @@ import com.example.BE.menu.repository.MenuRepository;
 import com.example.BE.store.domain.StoreEntity;
 import com.example.BE.store.repository.StoreRepository;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -79,7 +80,7 @@ public class MenuService {
 
     // 요청한 사용자가 메뉴를 생성/수정/삭제할 수 있는 권한을 가졌는지 확인
     private void validateStoreOwner(Long userId, StoreEntity store) {
-        if (!store.getUserId().equals(userId)) {
+        if (Objects.equals(store.getUserId(), userId)) {
             throw CustomException.from(MenuErrorCode.FORBIDDEN_MENU_ACCESS);
         }
     }

--- a/src/main/java/com/example/BE/store/controller/StoreApiController.java
+++ b/src/main/java/com/example/BE/store/controller/StoreApiController.java
@@ -33,7 +33,6 @@ public class StoreApiController {
     }
 
     // 가게 상세 정보 조회
-    // Menu, Announcement entity 추가한 뒤 구현 마무리할 예정
     @GetMapping("/{storeId}")
     public ResponseEntity<StoreDetailResponse> getStoreDetail(
         @PathVariable Long storeId

--- a/src/main/java/com/example/BE/store/domain/StoreEntity.java
+++ b/src/main/java/com/example/BE/store/domain/StoreEntity.java
@@ -1,5 +1,6 @@
 package com.example.BE.store.domain;
 
+import com.example.BE.store.domain.dto.StoreCreateRequest;
 import com.example.BE.store.domain.dto.StoreUpdateRequest;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
@@ -19,11 +20,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "store")
-@Builder
 @Getter
 @Access(AccessType.FIELD)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class StoreEntity {
 
     @Id
@@ -60,6 +59,37 @@ public class StoreEntity {
 
     @Column(name = "opening_time")
     private String openingTime;
+
+    @Builder
+    private StoreEntity(Long userId, String name, String canonicalName, String address,
+        Double latitude, Double longitude, String description, StoreCategory category,
+        String imageUrl, String openingTime) {
+            this.userId=userId;
+            this.name=name;
+            this.canonicalName=canonicalName;
+            this.address=address;
+            this.latitude=latitude;
+            this.longitude=longitude;
+            this.description=description;
+            this.category=category;
+            this.imageUrl=imageUrl;
+            this.openingTime=openingTime;
+    }
+
+    public static StoreEntity of(Long userId, StoreCreateRequest request) {
+        return new StoreEntity(
+            userId,
+            request.name(),
+            request.name().replaceAll("\\s+", ""),
+            request.address(),
+            request.latitude(),
+            request.longitude(),
+            request.description(),
+            request.category(),
+            request.imageUrl(),
+            request.openingTime()
+        );
+    }
 
     // 정보 수정 메서드
     public void update(StoreUpdateRequest request) {

--- a/src/main/java/com/example/BE/store/domain/StoreEntity.java
+++ b/src/main/java/com/example/BE/store/domain/StoreEntity.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -64,16 +63,16 @@ public class StoreEntity {
     private StoreEntity(Long userId, String name, String canonicalName, String address,
         Double latitude, Double longitude, String description, StoreCategory category,
         String imageUrl, String openingTime) {
-            this.userId=userId;
-            this.name=name;
-            this.canonicalName=canonicalName;
-            this.address=address;
-            this.latitude=latitude;
-            this.longitude=longitude;
-            this.description=description;
-            this.category=category;
-            this.imageUrl=imageUrl;
-            this.openingTime=openingTime;
+        this.userId = userId;
+        this.name = name;
+        this.canonicalName = canonicalName;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.description = description;
+        this.category = category;
+        this.imageUrl = imageUrl;
+        this.openingTime = openingTime;
     }
 
     public static StoreEntity of(Long userId, StoreCreateRequest request) {

--- a/src/main/java/com/example/BE/store/domain/dto/StoreDetailResponse.java
+++ b/src/main/java/com/example/BE/store/domain/dto/StoreDetailResponse.java
@@ -1,10 +1,11 @@
 package com.example.BE.store.domain.dto;
 
+import com.example.BE.announcement.domain.dto.AnnouncementResponse;
+import com.example.BE.menu.domain.dto.MenuResponse;
 import com.example.BE.store.domain.StoreEntity.StoreCategory;
+import java.util.List;
 
 public record StoreDetailResponse(
-    // 가게 정보, 메뉴 리스트, 개선사항(StoreAnnouncement) 리스트를 포함
-    // 이전 답변에서 설계한 DTO 구조를 활용
     Long id,
     String name,
     String canonicalName,
@@ -14,7 +15,26 @@ public record StoreDetailResponse(
     String description,
     StoreCategory category,
     String imageUrl,
-    String openingTime
-    //List<MenuResponse>,
-    //List<StoreAnnouncementResponse>
-) {}
+    String openingTime,
+    List<MenuResponse> menuList,
+    List<AnnouncementResponse> announcementList
+) {
+
+    public static StoreDetailResponse from(StoreResponse storeResponse,
+        List<MenuResponse> menuResponseList, List<AnnouncementResponse> announcementList) {
+        return new StoreDetailResponse(
+            storeResponse.id(),
+            storeResponse.name(),
+            storeResponse.canonicalName(),
+            storeResponse.address(),
+            storeResponse.latitude(),
+            storeResponse.longitude(),
+            storeResponse.description(),
+            storeResponse.category(),
+            storeResponse.imageUrl(),
+            storeResponse.openingTime(),
+            menuResponseList,
+            announcementList
+        );
+    }
+}

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -1,9 +1,11 @@
 package com.example.BE.store.service;
 
+import com.example.BE.announcement.domain.dto.AnnouncementResponse;
 import com.example.BE.announcement.repository.AnnouncementRepository;
+import com.example.BE.announcement.service.AnnouncementService;
 import com.example.BE.global.exception.CustomException;
-import com.example.BE.global.exception.errorCode.AnnouncementErrorCode;
 import com.example.BE.global.exception.errorCode.StoreErrorCode;
+import com.example.BE.menu.domain.dto.MenuResponse;
 import com.example.BE.menu.repository.MenuRepository;
 import com.example.BE.store.domain.StoreEntity;
 import com.example.BE.store.domain.dto.StoreCreateRequest;
@@ -27,6 +29,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
     private final AnnouncementRepository announcementRepository;
+    private final AnnouncementService announcementService;
 
     @Transactional
     public StoreResponse createStore(StoreCreateRequest request, Long userId) {
@@ -38,10 +41,14 @@ public class StoreService {
 
     public StoreDetailResponse getStoreDetail(Long storeId) {
         StoreEntity store = findByIdOrThrow(storeId);
-        // 메뉴, 개선사항 목록을 조회하고 조합: 아직 구현 전
-        // ...
-        // return new StoreDetailResponse();
-        return null;
+        StoreResponse storeResponse = StoreResponse.from(store);
+        List<MenuResponse> menuList = menuRepository.findByStoreId(storeId).stream()
+            .map(MenuResponse::from)
+            .toList();
+        List<AnnouncementResponse> announcementList = announcementService.getAnnouncementsByStoreId(
+            storeId);
+
+        return StoreDetailResponse.from(storeResponse, menuList, announcementList);
     }
 
     public List<StoreResponse> searchStores(double lat, double lon, String keyword) {

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -14,6 +14,7 @@ import com.example.BE.store.domain.dto.StoreResponse;
 import com.example.BE.store.domain.dto.StoreUpdateRequest;
 import com.example.BE.store.repository.StoreRepository;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class StoreService {
     }
 
     private void validateStoreOwner(StoreEntity store, Long userId) {
-        if (!store.getUserId().equals(userId)) {
+        if(!Objects.equals(store.getUserId(), userId)){
             throw CustomException.from(StoreErrorCode.FORBIDDEN_STORE_ACCESS);
         }
     }

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -28,13 +28,11 @@ public class StoreService {
 
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
-    private final AnnouncementRepository announcementRepository;
     private final AnnouncementService announcementService;
 
     @Transactional
     public StoreResponse createStore(StoreCreateRequest request, Long userId) {
         StoreEntity newStore = StoreEntity.of(userId, request);
-        validateStoreOwner(newStore, userId);
 
         return StoreResponse.from(storeRepository.save(newStore));
     }

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -1,7 +1,6 @@
 package com.example.BE.store.service;
 
 import com.example.BE.announcement.domain.dto.AnnouncementResponse;
-import com.example.BE.announcement.repository.AnnouncementRepository;
 import com.example.BE.announcement.service.AnnouncementService;
 import com.example.BE.global.exception.CustomException;
 import com.example.BE.global.exception.errorCode.StoreErrorCode;

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -29,18 +29,7 @@ public class StoreService {
 
     @Transactional
     public StoreResponse createStore(StoreCreateRequest request, Long userId) {
-        StoreEntity newStore = StoreEntity.builder()
-            .userId(userId)
-            .name(request.name())
-            .canonicalName(request.name().replaceAll("\\s+", ""))
-            .address(request.address())
-            .latitude(request.latitude())
-            .longitude(request.longitude())
-            .description(request.description())
-            .category(request.category())
-            .imageUrl(request.imageUrl())
-            .openingTime(request.openingTime())
-            .build();
+        StoreEntity newStore = StoreEntity.of(userId, request);
         return StoreResponse.from(storeRepository.save(newStore));
     }
 

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -1,21 +1,22 @@
 package com.example.BE.store.service;
 
+import com.example.BE.announcement.repository.AnnouncementRepository;
 import com.example.BE.global.exception.CustomException;
+import com.example.BE.global.exception.errorCode.AnnouncementErrorCode;
 import com.example.BE.global.exception.errorCode.StoreErrorCode;
+import com.example.BE.menu.repository.MenuRepository;
 import com.example.BE.store.domain.StoreEntity;
 import com.example.BE.store.domain.dto.StoreCreateRequest;
 import com.example.BE.store.domain.dto.StoreDetailResponse;
 import com.example.BE.store.domain.dto.StoreResponse;
 import com.example.BE.store.domain.dto.StoreUpdateRequest;
 import com.example.BE.store.repository.StoreRepository;
-import java.util.Objects;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,12 +25,14 @@ import java.util.stream.Collectors;
 public class StoreService {
 
     private final StoreRepository storeRepository;
-    //private final MenuRepository menuRepository; // 상세 조회를 위해 주입
-    //private final StoreAnnouncementRepository announcementRepository; // 상세 조회를 위해 주입
+    private final MenuRepository menuRepository;
+    private final AnnouncementRepository announcementRepository;
 
     @Transactional
     public StoreResponse createStore(StoreCreateRequest request, Long userId) {
         StoreEntity newStore = StoreEntity.of(userId, request);
+        validateStoreOwner(newStore, userId);
+
         return StoreResponse.from(storeRepository.save(newStore));
     }
 
@@ -43,21 +46,16 @@ public class StoreService {
 
     public List<StoreResponse> searchStores(double lat, double lon, String keyword) {
         final int radius = 2000; // 2km 반경으로 고정
-        List<StoreEntity> stores = storeRepository.findNearbyStoresWithKeyword(lat, lon, radius, keyword);
+        List<StoreEntity> stores = storeRepository.findNearbyStoresWithKeyword(lat, lon, radius,
+            keyword);
         return stores.stream().map(StoreResponse::from).collect(Collectors.toList());
     }
 
     @Transactional
     public StoreResponse updateStore(Long storeId, StoreUpdateRequest request, Long userId) {
         StoreEntity store = findByIdOrThrow(storeId);
-        // 가게 주인 본인인지 확인
-//        log.info("storeId: {}", storeId);
-//        log.info("store userId: {}", store.getUserId());
-//        log.info("request userId: {}", userId);
+        validateStoreOwner(store, userId);
 
-        if (!store.getUserId().equals(userId)) {
-            throw CustomException.from(StoreErrorCode.FORBIDDEN_STORE_ACCESS);
-        }
         store.update(request);
         return StoreResponse.from(store);
     }
@@ -65,10 +63,7 @@ public class StoreService {
     @Transactional
     public void deleteStore(Long userId, Long storeId) {
         StoreEntity store = findByIdOrThrow(storeId);
-
-        if(!store.getUserId().equals(userId)){
-            throw CustomException.from(StoreErrorCode.FORBIDDEN_STORE_ACCESS);
-        }
+        validateStoreOwner(store, userId);
 
         storeRepository.deleteById(storeId);
     }
@@ -76,5 +71,11 @@ public class StoreService {
     private StoreEntity findByIdOrThrow(Long storeId) {
         return storeRepository.findById(storeId)
             .orElseThrow(() -> CustomException.from(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    private void validateStoreOwner(StoreEntity store, Long userId) {
+        if (!store.getUserId().equals(userId)) {
+            throw CustomException.from(StoreErrorCode.FORBIDDEN_STORE_ACCESS);
+        }
     }
 }


### PR DESCRIPTION
## ✨ 요약
- 지도 페이지에 사용할 가게 상세 정보 조회 API를 구현했어요.
- 가게 기본 정보 + 메뉴 리스트 + 가게 개선사항까지 모두 한 번에 조회하는 API입니다.

<br><br>

## 🔗 작업 내용
- StoreEntity 생성 메서드를 builder 패턴 -> from 메서드로 변경
- 가게 정보 생성/수정/삭제할 때 본인 가게에만 접근할 수 있도록 검증 로직 추가
- 가게 상세 정보 조회 API 구현

<br><br>

## 🔗 참고 사항
- JPA 연관관계 매핑을 안 하니까 이게 갈수록 일이 커지는 느낌인데요 ㅋㅋ.....

<br><br>

## 🔗 관련 이슈

- #15

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 매장 상세 조회에 메뉴 목록과 공지 목록이 추가되어 한 화면에서 매장 정보, 메뉴 및 공지를 함께 확인할 수 있습니다.

* **버그 수정**
  * 소유자 권한 검증이 중앙화되어 업데이트/삭제 시 일관된 접근 제어가 적용됩니다.
  * 권한 검사 비교 방식이 안전하게 변경되어 일부 널 관련 오류 가능성이 줄었습니다.

* **기타**
  * 기존 목록 조회·생성·수정·삭제의 외형적 동작은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->