### PR TITLE
refactor: # 33 docker-compose.server.yml 피드백 반영

### DIFF
--- a/docker-compose/docker-compose.server.yml
+++ b/docker-compose/docker-compose.server.yml
@@ -24,7 +24,7 @@ services:
       - ${DB_PORT}
     ports:
       - ${DB_PORT}:${DB_PORT}
-    restart: "no"
+    restart: "unless-stopped"
     volumes:
       - moa-database:/var/lib/mysql
     networks:

--- a/docker-compose/docker-compose.server.yml
+++ b/docker-compose/docker-compose.server.yml
@@ -6,9 +6,7 @@ services:
       - ${ENV_FILE}
     depends_on:
       - database
-    ports:
-      - ${SPRING_PORT}:${SPRING_PORT}
-    restart: "no"
+    restart: "unless-stopped"
     networks:
       - moa-bridge
 
@@ -16,7 +14,6 @@ services:
     image: mysql:8.4.4
     container_name: moa-database
     environment:
-      DB_URL: ${DB_URL}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_USER: ${DB_USERNAME}


### PR DESCRIPTION
## ✨ 요약
- #33 PR의 리뷰를 반영했어요

<br><br>

## 🔗 작업 내용
- docker-compose.server.yml 파일에 리뷰를 반영했어요.
- app service의 restart 옵션을 수정했어요.
- database service에서 사용하지 않는 옵션을 삭제했어요.

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈


<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 작업(Chores)
  - 서버 컨테이너 재시작 정책을 "unless-stopped"로 전환해 장애 시 자동 재시작으로 가용성 및 복구력 향상.
  - 애플리케이션의 호스트 포트 공개를 중단해 불필요한 외부 노출 감소 및 운영 보안 강화.
  - 데이터베이스 컨테이너에서 DB_URL 환경변수를 제거해 설정 정리(포트 노출 동작은 유지).
  - 사용자 기능 변화 없음; 안정성·운영성 개선에 집중.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->