### PR TITLE
chore: 오타 수정

### DIFF
--- a/docker-compose/docker-compose.server.yml
+++ b/docker-compose/docker-compose.server.yml
@@ -6,6 +6,8 @@ services:
       - ${ENV_FILE}
     depends_on:
       - database
+    ports:
+      - ${SPRING_PORT}:${SPRING_PORT}
     restart: "unless-stopped"
     networks:
       - moa-bridge

--- a/src/main/java/com/example/BE/global/config/WebConfig.java
+++ b/src/main/java/com/example/BE/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3000", "http://localhost:5174", "http://localhost:8080")
+            .allowedOrigins("http://localhost:3000", "http://localhost:5173", "http://localhost:8080")
             .allowedMethods("GET", "POST", "PATCH", "DELETE")
             .allowedHeaders("*")
             .allowCredentials(true)


### PR DESCRIPTION
## ✨ 요약
- 

<br><br>

## 🔗 작업 내용
- 

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈

- Close #이슈번호

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CORS 허용 오리진에서 http://localhost:5174를 http://localhost:5173으로 변경했습니다. 다른 오리진 및 CORS 설정은 동일합니다. 로컬 환경에서의 API 호출 호환성이 개선됩니다.
- **Chores**
  - 서버용 docker-compose에 앱 서비스 포트 매핑을 추가했습니다: SPRING_PORT를 호스트와 컨테이너에서 동일 포트로 노출합니다. 다른 서비스, 볼륨, 네트워크 설정은 변경 없습니다. 로컬 접근성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->