### PR TITLE
refactor: user api 경로 수정

### DIFF
--- a/src/main/java/com/example/BE/user/controller/UserApiController.java
+++ b/src/main/java/com/example/BE/user/controller/UserApiController.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,42 +24,42 @@ public class UserApiController {
 
     private final UserService userService;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/")
     public ResponseEntity<UserResponse> getUser(
-            @PathVariable Long userId
+        @AuthenticationPrincipal Long userId
     ) {
         UserResponse userResponse = userService.findById(userId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userResponse);
+            .body(userResponse);
     }
 
     // 유저 프로필 수정
-    @PatchMapping("/{userId}")
+    @PatchMapping("/")
     public ResponseEntity<UserResponse> updateUser(
-            @PathVariable Long userId,
-            @Valid @RequestBody UserUpdateRequest request
+        @AuthenticationPrincipal Long userId,
+        @Valid @RequestBody UserUpdateRequest request
     ) {
         UserResponse userResponse = userService.updateProfile(userId, request);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userResponse);
+            .body(userResponse);
     }
 
     // 유저 삭제
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/")
     public ResponseEntity<MessageResponse> deleteUser(
-            @PathVariable Long userId
+        @AuthenticationPrincipal Long userId
     ) {
         userService.deleteUser(userId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(MessageResponse.from("회원 탈퇴가 완료되었습니다."));
+            .body(MessageResponse.from("회원 탈퇴가 완료되었습니다."));
     }
 
-    @GetMapping("my")
+    @GetMapping("/my")
     public ResponseEntity<UserDetailResponse> getMyUser(
-            @AuthenticationPrincipal Long userId
+        @AuthenticationPrincipal Long userId
     ) {
         UserDetailResponse userDetailResponse = userService.getMyUser(userId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userDetailResponse);
+            .body(userDetailResponse);
     }
 }


### PR DESCRIPTION
## ✨ 요약
- user api의 요구 경로를 수정했습니다.

<br><br>

## 🔗 작업 내용
- path variable로 userId를 전달하지 않고, 헤더에 담긴 토큰에서 추출해서 사용합니다.

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈


<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 사용자 관련 엔드포인트가 경로 파라미터 기반(/{userId})에서 인증 컨텍스트 기반(/)으로 변경되었습니다.
  - 클라이언트는 더 이상 userId를 경로로 전달하지 않으며, 인증 상태에서 호출해야 합니다.
  - 내 정보 조회 경로 표기를 "my"에서 "/my"로 정리했으며, 기존 베이스 경로 하에서 동일하게 동작합니다.
  - 응답 형식과 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->