### PR TITLE
feat: 본인 가게 정보 조회 기능 구현(사장님용)

### DIFF
--- a/src/main/java/com/example/BE/store/controller/StoreApiController.java
+++ b/src/main/java/com/example/BE/store/controller/StoreApiController.java
@@ -42,6 +42,16 @@ public class StoreApiController {
             .body(response);
     }
 
+    // 사장님용: 본인 가게 정보 조회
+    @GetMapping("/my")
+    public ResponseEntity<StoreResponse> getMyStore(
+        @AuthenticationPrincipal Long userId
+    ){
+        StoreResponse response = storeService.getMyStore(userId);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(response);
+    }
+
     // 가게별 평균 평점 조회
     @GetMapping("/{storeId}/ratings")
     public ResponseEntity<?> getRatings(

--- a/src/main/java/com/example/BE/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/BE/store/repository/StoreRepository.java
@@ -12,6 +12,8 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
     // 키워드 검색 (공백 없는 이름으로 검색)
     Optional<StoreEntity> findByCanonicalName(String canonicalName);
 
+    Optional<StoreEntity> findByUserId(Long userId);
+
     // 이거는 근데 AI 도움을 받은 거라 테스트 좀 해 봐야 해요.
     // 지도 검색을 위한 공간 쿼리 (MySQL 기준)
     @Query(value = "SELECT * FROM stores s " +

--- a/src/main/java/com/example/BE/store/service/StoreService.java
+++ b/src/main/java/com/example/BE/store/service/StoreService.java
@@ -52,6 +52,13 @@ public class StoreService {
         return StoreDetailResponse.from(storeResponse, menuList, announcementList);
     }
 
+    public StoreResponse getMyStore(Long userId){
+        StoreEntity store = storeRepository.findByUserId(userId)
+            .orElseThrow(()->CustomException.from(StoreErrorCode.STORE_NOT_FOUND));
+
+        return StoreResponse.from(store);
+    }
+
     public Double getAverageRatings(Long storeId) {
         StoreEntity store = findByIdOrThrow(storeId);
         List<FeedbackEntity> list = feedbackRepository.findAllByStoreId(storeId);


### PR DESCRIPTION
## ✨ 요약
- 

<br><br>

## 🔗 작업 내용
- 

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈

- Close #이슈번호

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증 기반 점주 전용 상점 조회 엔드포인트 추가: GET /api/store/my. 로그인한 사용자 기준으로 자신의 상점 정보를 단일 호출로 받아볼 수 있습니다.
  - 상점이 없는 경우 표준화된 오류 응답을 반환하여 클라이언트에서 상태를 명확히 처리할 수 있습니다.
  - 기존 공개 API의 동작, 응답 형식, 권한 정책에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->