### PR TITLE
feat: 멀티파트 최대 용량 설정 및 피드백 서비스 로직 변경

### DIFF
--- a/src/main/java/com/example/BE/feedback/service/FeedbackService.java
+++ b/src/main/java/com/example/BE/feedback/service/FeedbackService.java
@@ -61,12 +61,7 @@ public class FeedbackService {
 
     @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
     public List<FeedbackDetailResponse> getMyFeedbacks(Long userId) {
-        List<FeedbackDetailResponse> feedbacks = feedbackRepository.findMyFeedbacks(userId);
-        if (feedbacks.isEmpty()) {
-            throw CustomException.from(FeedbackErrorCode.FEEDBACK_NOT_FOUND);
-        }
-
-        return feedbacks;
+        return feedbackRepository.findMyFeedbacks(userId);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,9 @@ spring:
 # 요청 응답에 모두 한글 인코딩 강제 적용
 server:
   servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 30MB
     encoding:
       charset: UTF-8
       enabled: true


### PR DESCRIPTION


## 🔗 작업 내용

설정 업데이트: application.yml 파일에서 멀티파트(multipart) 업로드의 최대 파일 크기를 파일당 10MB로, 전체 요청 크기를 30MB로 상향 조정했습니다.

서비스 로직 간소화: FeedbackService.getMyFeedbacks 메서드에서 피드백 목록이 비어 있을 때 예외를 발생시키던 로직을 제거했습니다. 이제 피드백이 없으면 오류 대신 **빈 목록([])**을 반환합니다.

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈

- Close #이슈번호

<br><br>
